### PR TITLE
docs: clarify observed API behaviours (rights inheritance, formulas, properties, auth)

### DIFF
--- a/src/api/authentication/index.md
+++ b/src/api/authentication/index.md
@@ -100,6 +100,24 @@ The exchange must originate from the same browser that completed the login — s
 Always validate the `next` URL in your app before using the token. Only accept HTTPS URLs and reject any redirect to an origin you do not control.
 :::
 
+## Adding a Login Method to an Existing Account
+
+A signed-in user can attach an additional OAuth identity — a second email, a Google account, an Apple ID — to their existing person entity, without administrator involvement. The mechanism reuses the invite flow as a self-link:
+
+1. The app adds a placeholder `entu_user` property to the user's own person entity, carrying an invite token and the new email:
+   ```json
+   { "type": "entu_user", "invite": "<token>", "email": "new@example.com" }
+   ```
+2. The app emails an invite link (referencing that person entity) to the new address.
+3. The user opens the link and completes the e-mail (or other provider) OAuth flow. Because the invited entity is the user's own person, Entu links the new credential onto it rather than creating a new person.
+4. The person entity now carries two (or more) `entu_user` entries; a future login through either identity resolves to the same person.
+
+This works for any supported provider and needs only `_editor` rights on the person entity — which users hold on their own entity by default.
+
+::: info
+This reuses the same path as new-user invite acceptance. A dedicated account-linking endpoint is under discussion — see [entu/api#39](https://github.com/entu/api/issues/39).
+:::
+
 ## Auth Properties
 
 Authentication credentials are stored as properties on an entity. By default these are used on person entities — each person entity represents a human user. But the same properties can be added to any entity type, which lets non-human actors authenticate too. A `robot` entity in an IoT setup, a `screen` entity in a digital signage system, or a `service` entity for a backend integration can all have their own API key and authenticate independently.

--- a/src/api/formulas/index.md
+++ b/src/api/formulas/index.md
@@ -10,6 +10,10 @@ Formulas are evaluated in two passes so that properties depending on other formu
 Two-pass evaluation means a formula can safely reference another computed property on the same entity. The first pass resolves simple fields; the second resolves dependencies between computed properties.
 :::
 
+::: warning Output is a scalar, never a reference
+A formula always stores a scalar result — `string`, `number`, or `boolean`, whichever its operators produce. It never produces a `reference` value. Declaring `type: reference` on a formula property has no effect: the result is stored as a string. For an honest schema, declare formula properties that surface reference-like text as `type: string`.
+:::
+
 ## Syntax
 
 Formulas use **Reverse Polish Notation** (RPN, also known as postfix notation): values come first, the operator comes last. The engine walks the formula left to right with a single value stack. Each token either:
@@ -74,6 +78,12 @@ Entu properties are multi-value: a single field reference may push a list of N v
 | `propertyName.*._id` | IDs of all referenced entities |
 | `propertyName.type._id` | IDs of referenced entities filtered by type |
 
+::: warning Single-hop only
+A reference resolves exactly **one** hop from the current entity. `propertyName.*.property` reads a property on the directly-referenced entity. A second hop — for example continuing through `_parent` or another reference after the first (`ref.*._parent.*.name`) — resolves to nothing: the formula property is silently left unwritten rather than raising an error.
+
+To traverse two levels, define an intermediate formula property on the referenced entity that exposes the value you need, then read that property in a single hop.
+:::
+
 ### Child Entities
 
 | Reference | Resolves to |
@@ -102,6 +112,14 @@ A referrer is an entity that points at the current entity through a user-defined
 
 ::: info
 Unlike same-entity formulas, a `_referrer` formula depends on **other** entities. Its value updates when a referencing entity is created, changed, deleted, or has its reference changed — Entu then queues the target entity for automatic re-aggregation so its `_referrer` (and `_child`) formulas recompute. The result is eventually consistent: it may not be updated within the same request that changed the referencing entity.
+:::
+
+::: warning Formula evaluation bypasses access rights
+The formula evaluator reads referenced, child, and referrer entities directly, without applying the requesting user's access rights. A formula on entity A can incorporate data from entity B even when the viewer has no rights to read B on its own.
+
+This is deliberate — it enables roll-ups across access boundaries (a parent counting or summing restricted children). But it means a formula that projects **raw values** (names, emails, descriptions) from a restricted entity exposes those values to anyone who can read the formula-bearing entity. Reserve cross-entity formulas for aggregates (`COUNT`, `SUM`, `AVERAGE`, `MIN`, `MAX`); avoid projecting raw fields across a rights boundary.
+
+The exposure is bounded by who can write formulas: only users who can edit the entity-type definition (typically administrators) can add or change one.
 :::
 
 ## Operators
@@ -165,6 +183,14 @@ Most operators return no value (the property is not written) when their inputs r
 | `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE` | empty side → no value |
 | `EXISTS` | always returns a boolean |
 | `IF`, `WHEN` | no value if `cond` is empty or not a single boolean; `WHEN` returns no value when `cond` is `false` |
+
+::: info CONCAT_WS with partial and duplicate inputs
+When only some inputs resolve, `CONCAT_WS` joins the present values and emits no stray separators: `a b ' / ' CONCAT_WS` with only `a` set returns `"A"`, not `"A / "`. (All inputs absent returns no value.)
+
+Values are joined **verbatim, without deduplication** — if the same value appears more than once across the inputs or within a list-valued field, it appears more than once in the output (`["en","et"] ["la","en"] ' / ' CONCAT_WS` → `"en / et / la / en"`).
+
+There is no `COALESCE` or `FIRST` operator. To express "use `a`, otherwise `b`", handle the fallback in your application layer.
+:::
 
 ## Examples
 

--- a/src/api/properties/index.md
+++ b/src/api/properties/index.md
@@ -143,3 +143,7 @@ Returns `{ "deleted": true }` on success. Deletion is a soft-delete — the prop
 ::: warning
 Deleting `_type` always returns `403`. To change an entity's type, overwrite the existing value by POSTing with the old property `_id` and a new reference — see [Overwriting a Property Value](#overwriting-a-property-value).
 :::
+
+::: warning The last-`_owner` guard is direct-delete only
+The "at least one `_owner` must remain" rule is enforced on a direct `DELETE /property/{_id}` of the last owner (it returns `403`). It does not guard the indirect paths: deleting a parent entity, or flipping `_inheritrights` on a child whose only `_owner` was inherited, can leave an entity with no effective owner. When you rely on inheritance for ownership, make sure each entity also retains an explicit `_owner`.
+:::

--- a/src/configuration/entity-types/index.md
+++ b/src/configuration/entity-types/index.md
@@ -90,6 +90,12 @@ On the entity type's page, use the "Add" button to create child entities of type
 Enable `search` on properties users frequently filter by (e.g. `name`, `status`, `reference code`).
 :::
 
+::: info `reference_query` is a static filter
+`reference_query` is evaluated as a fixed query string — it does **not** support per-instance placeholders such as `{{_parent}}` or references to the current record. The same filter applies to every picker for this property, regardless of which entity is being edited. To scope a picker by the current record's context (e.g. "only members of *this* entity's organisation"), enforce it in your application or BFF layer.
+
+Access rights always apply on top of `reference_query`: users only ever see entities they already have rights to, so the picker can never surface records they shouldn't.
+:::
+
 ### Property Types
 
 Available types: `string`, `text`, `number`, `boolean`, `date`, `datetime`, `file`, `reference`, `counter`.

--- a/src/overview/entities/index.md
+++ b/src/overview/entities/index.md
@@ -18,6 +18,20 @@ To define your data model in the UI, see [Entity Types](/configuration/entity-ty
 
 **Audit trail** — All property values carry creation metadata (timestamp and user), making it traceable who set what and when.
 
+## What Propagates Between Entities
+
+Entities relate to each other in two ways, and they behave differently at runtime:
+
+| Relationship | What propagates at runtime |
+|---|---|
+| **Entity type ↔ instance** | The type is a blueprint and UI hint, not a parent. Property *definitions* on the type shape how instances behave, but the type entity's own system properties (its `_sharing`, its rights) are **not** inherited by instances, and editing a definition does **not** retroactively rewrite existing instances. |
+| **Parent ↔ child** | Access rights (`_owner` / `_editor` / `_expander` / `_viewer`) cascade — and only when the child has `_inheritrights: true`. This is Entu's only built-in entity-to-entity cascade. |
+
+**Practical implications**
+
+- `_sharing: public` on an entity *type* does not make its instances public. The type's `_sharing` only caps property projection (see [Entity Type Visibility](/configuration/entity-types/#visibility)); each instance's accessibility is governed by `_sharing` and rights on that instance.
+- Editing a property's `formula` on the type does not retroactively recompute existing instances — re-save an instance (or let a referenced change trigger re-aggregation) to materialise the new value.
+
 ## Hierarchy and Relationships
 
 Entities are organised into hierarchies using the `_parent` system property.
@@ -70,6 +84,18 @@ Set `_inheritrights: true` on an entity to inherit rights from its parent. Right
 
 ::: info
 Right evaluation order: explicit rights on the entity → inherited rights from parent → `_sharing` level. `_noaccess` overrides all other rights on the same entity — including direct positive rights. It is not propagated to children via `_inheritrights`; only `_viewer`, `_expander`, `_editor`, and `_owner` are inherited.
+:::
+
+### Multi-parent inheritance
+
+When `_inheritrights: true` is set on an entity with more than one parent, the child's effective rights are the **union** of all parents' rights. An entity parented under both A and B inherits every right that either parent grants.
+
+Inherited rights are **materialised** — physically written onto the child — not computed at read time. They appear in `GET /entity/{id}` responses just like directly-set rights. Granting a higher tier also materialises the lower tiers it includes: an inherited `_editor` appears alongside `_expander` and `_viewer` for the same person.
+
+Each rights entry the API returns may carry an `inherited: true` field, marking it as materialised from a parent rather than set explicitly on this entity. Directly-granted entries do not carry the field; if a person is granted both explicitly and by inheritance, the entries merge into a single explicit entry. To read only directly-granted rights, filter out entries where `inherited` is `true`.
+
+::: info
+Rights propagation is eventually consistent, not synchronous. Through a chain of `_inheritrights: true` entities it applies sequentially, one level at a time, so a grant near the root of a deep chain can take a few seconds to reach the leaf. Allow for this before relying on freshly-changed rights.
 :::
 
 ## Deletion


### PR DESCRIPTION
Documents several Entu API/platform behaviours that we (the team behind **mvox**, an Entu-backed app) verified empirically against a live database while building on Entu, but which were not yet covered in the docs. Each addition maps to an open issue with probe results, listed below so this single merge closes them.

Pure markdown additions in `src/` (English) using the existing `:::` admonition style. We deliberately left the Estonian `src/et/` mirror untouched — happy to follow up with translations, but the wording is yours to finalise first.

## What is documented

| Area | Addition | Issue |
|---|---|---|
| Entities | "What propagates between entities" (type↔instance vs parent↔child) | #10 |
| Entities | Multi-parent rights = union, materialised, eventually consistent, `inherited` flag | #2 |
| Formulas | Single-hop references only | #4 |
| Formulas | Output is always a scalar, never a reference | #8 |
| Formulas | Evaluator bypasses access rights (safe for aggregates, not raw projection) | #9 |
| Formulas | `CONCAT_WS` partial/duplicate-input behaviour | #3 |
| Properties | Last-`_owner` guard is direct-delete only | #6 |
| Authentication | Add-a-login-method (invite self-link) flow | #7 |
| Entity Types | `reference_query` is a static filter | #5 |

## Notes

- These behaviours were observed against a live Entu deployment; we have phrased them as observations and would welcome correction on anything that is deployment-specific rather than universal.
- A couple touch security-relevant behaviour (formula rights bypass, last-owner guard) — flagged as warnings so integrators design around them.

Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10