### PR TITLE
docs: explicitly state that _sharing is not inherited and defaults to private

### DIFF
--- a/src/overview/entities/index.md
+++ b/src/overview/entities/index.md
@@ -64,6 +64,10 @@ Editing always requires `_editor` or `_owner` rights regardless of sharing level
 Setting `_sharing: public` makes the entity visible to anyone on the internet without authentication. Only use it for intentionally public content.
 :::
 
+::: info
+`_sharing` is per-entity only — it is **not** propagated to children via `_inheritrights`. An entity with no explicit `_sharing` value defaults to `private`, regardless of its parent's `_sharing` setting.
+:::
+
 ### Rights Inheritance
 
 Set `_inheritrights: true` on an entity to inherit rights from its parent. Rights defined directly on the child override inherited ones. Use `_noaccess` to block a user who would otherwise inherit access from a parent.


### PR DESCRIPTION
One-line clarification in the Sharing section of `src/overview/entities/index.md`.

The existing docs describe `_sharing` defaults ("private is the default") and `_inheritrights` propagation ("only `_viewer`, `_expander`, `_editor`, and `_owner` are inherited") in separate sections, but neither explicitly states the combined behaviour: **`_sharing` is not propagated via `_inheritrights`, and an entity with no explicit `_sharing` defaults to `private` regardless of its parent's setting.**

We've now seen two independent integrator teams assume `_sharing` inherits from the parent (like the four rights do), and design bulk operations around that wrong model. A single explicit sentence prevents this.

Closes #12